### PR TITLE
Fix bug that caused data files to not load when starting the Application

### DIFF
--- a/src/main/java/seedu/address/storage/JsonSerializableDeletedSources.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableDeletedSources.java
@@ -27,7 +27,7 @@ public class JsonSerializableDeletedSources {
      * Constructs a {@code JsonSerializableDeletedSources} with the given sources.
      */
     @JsonCreator
-    public JsonSerializableDeletedSources(@JsonProperty("sources") List<JsonAdaptedSource> sources) {
+    public JsonSerializableDeletedSources(@JsonProperty("deletedSources") List<JsonAdaptedSource> sources) {
         this.deletedSources.addAll(sources);
     }
 


### PR DESCRIPTION
How to replicate this bug: 
Run the application after the deletesource.json file has been created in the data folder, no data will be loaded including the sourcemanager.json

What was fixed:
Changed JsonProperty naming in JsonSerializableDeletedSources.java to `deletedSources` instead of `sources` because deletesource.json is using this naming.

#141 