### PR TITLE
Major Fixes for Duplicate Sources bugs

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -84,6 +84,7 @@ Format: `delete INDEX`
 * Deletes the source at the specified `INDEX`.
 * The index refers to the index number shown in the displayed source list.
 * The index *must be a positive integer* 1, 2, 3, ...
+* If source to delete is already in the deleted sources list, it will be permanently deleted.
 ****
 
 Examples:
@@ -94,6 +95,11 @@ Deletes the 2nd source in the database.
 * `search algorithms` +
 `delete 1` +
 Deletes the 1st source in the results of the `search` command.
+* `add i/Wikipedia Algorithms y/Website d/Basic definitions of algorithms t/Algorithms t/Introduction` +
+`delete 1` +
+* `add i/Wikipedia Algorithms y/Website d/Basic definitions of algorithms t/Algorithms t/Introduction` +
+`delete 1` +
+Permanently deletes the 1st source that is exactly the same source as the source that was previously deleted.
 
 
 === Restoring a source : `restore`

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -8,7 +8,8 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command.";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_SOURCE_DISPLAYED_INDEX = "The source index provided is invalid";
-    public static final String MESSAGE_INVALID_DELETED_SOURCE_DISPLAYED_INDEX = "The source index provided is invalid";
+    public static final String MESSAGE_DUPLICATE_SOURCE_TO_RESTORE = "The source you are trying to restore already "
+            + "exists in the current source list.\nThe duplicate source will be removed from your deleted source list.";
     public static final String MESSAGE_SOURCES_LISTED_OVERVIEW = "%1$d sources listed!";
 
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -37,10 +37,15 @@ public class DeleteCommand extends Command {
         List<Source> lastShownList = model.getFilteredSourceList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_DELETED_SOURCE_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MESSAGE_INVALID_SOURCE_DISPLAYED_INDEX);
         }
 
         Source sourceToDelete = lastShownList.get(targetIndex.getZeroBased());
+
+        // permanently delete if the exact same source exists in deleted sources list
+        if (model.hasDeletedSource(sourceToDelete)) {
+            model.removeDeletedSource(sourceToDelete);
+        }
 
         model.addDeletedSource(sourceToDelete);
         model.deleteSource(sourceToDelete);

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -42,9 +42,10 @@ public class DeleteCommand extends Command {
 
         Source sourceToDelete = lastShownList.get(targetIndex.getZeroBased());
 
-        // permanently delete if the exact same source exists in deleted sources list
+        // permanently delete from source manager list if the exact same source exists in deleted source list
         if (model.hasDeletedSource(sourceToDelete)) {
-            model.removeDeletedSource(sourceToDelete);
+            model.deleteSource(sourceToDelete);
+            return new CommandResult(String.format(MESSAGE_DELETE_SOURCE_SUCCESS, sourceToDelete));
         }
 
         model.addDeletedSource(sourceToDelete);

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -12,7 +12,7 @@ import seedu.address.model.Model;
 import seedu.address.model.source.Source;
 
 /**
- * Deletes a source identified using it's displayed index from the address book.
+ * Deletes a source identified using it's displayed index from the source manager.
  */
 public class DeleteCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/RestoreCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RestoreCommand.java
@@ -42,6 +42,13 @@ public class RestoreCommand extends Command {
 
         Source toRestore = lastShownDeletedList.get(targetIndex.getZeroBased());
 
+        // permanently deletes duplicate source if the exact same source exists in source manager
+        if (model.hasSource(toRestore)) {
+            model.removeDeletedSource(toRestore);
+            model.commitDeletedSources();
+            return new CommandResult(String.format(Messages.MESSAGE_DUPLICATE_SOURCE_TO_RESTORE, toRestore));
+        }
+
         model.addSource(toRestore);
         model.removeDeletedSource(toRestore);
         model.commitSourceManager();

--- a/src/main/java/seedu/address/logic/commands/RestoreCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RestoreCommand.java
@@ -42,7 +42,7 @@ public class RestoreCommand extends Command {
 
         Source toRestore = lastShownDeletedList.get(targetIndex.getZeroBased());
 
-        // permanently deletes duplicate source if the exact same source exists in source manager
+        // removes duplicate source from deleted source list if the exact same source exists in source manager
         if (model.hasSource(toRestore)) {
             model.removeDeletedSource(toRestore);
             model.commitDeletedSources();

--- a/src/main/java/seedu/address/model/source/Source.java
+++ b/src/main/java/seedu/address/model/source/Source.java
@@ -77,17 +77,19 @@ public class Source {
     }
 
     /**
-     * Returns true if both sources of the same title have at least one other identity field that is the same.
+     * Returns true if both sources of the have the same title and same detail.
+     * Two sources will only be the same if they have the same title and same details.
      * This defines a weaker notion of equality between two sources.
      */
     public boolean isSameSource(Source otherSource) {
-        if (otherSource == this) {
+        if (otherSource.getTitle().title.equals(this.getTitle())
+                && otherSource.getDetail().detail.equals(this.getDetail())) {
             return true;
         }
 
         return otherSource != null
                 && otherSource.getTitle().equals(getTitle())
-                && (otherSource.getType().equals(getType()) || otherSource.getDetail().equals(getDetail()));
+                && otherSource.getDetail().equals(getDetail());
     }
 
     /**

--- a/src/test/data/JsonSerializableSourceManagerTest/duplicateSourceSourceManager.json
+++ b/src/test/data/JsonSerializableSourceManagerTest/duplicateSourceSourceManager.json
@@ -7,6 +7,6 @@
   }, {
     "title": "Alice Pauline",
     "type": "94351253",
-    "detail": "pauline@example.com"
+    "detail": "alice@example.com"
   } ]
 }

--- a/src/test/java/seedu/address/model/SourceManagerTest.java
+++ b/src/test/java/seedu/address/model/SourceManagerTest.java
@@ -51,7 +51,7 @@ public class SourceManagerTest {
     @Test
     public void resetData_withDuplicateSources_throwsDuplicateSourceException() {
         // Two sources with the same fields
-        Source editedAlice = new SourceBuilder(ALICE).withDetail("foo").withTags("bar").build();
+        Source editedAlice = new SourceBuilder(ALICE).withDetail("alice_detail").withTags("bar").build();
         List<Source> newSources = Arrays.asList(ALICE, editedAlice);
         SourceManagerStub newData = new SourceManagerStub(newSources);
 
@@ -79,7 +79,7 @@ public class SourceManagerTest {
     @Test
     public void hasSource_sourceWithSameFieldsInSourceManager_returnsTrue() {
         sourceManager.addSource(ALICE);
-        Source editedAlice = new SourceBuilder(ALICE).withDetail("foo").withTags("bar").build();
+        Source editedAlice = new SourceBuilder(ALICE).withDetail("alice_detail").withTags("bar").build();
         assertTrue(sourceManager.hasSource(editedAlice));
     }
 


### PR DESCRIPTION
1.  Fix bug that allows users to edit sources into the same source: change isSameSource method in Source model to detect that sources are the same only when they both have the same `title` and same `detail`.
2. Fix bug that doesn't allow users to delete sources when there is a duplicate source in the deleted source list (`deletesource.json`)
Documentation will be updated accordingly in the future: 
- warn users that they will not be able to **add a source existing in the database** or **edit a source into the same source**
- our rationale to not allow for sources with the same `detail` and same `title`: because even though there may be research data with the same title/type/tags, if they have the same detail, it means they are the same research. (explain in DeveloperGuide.adoc)
- rationale to delete source from deleted source list when trying to `restore` a source that already exists in the source manager list (explain in DeveloperGuide.adoc)
- rationale to delete source from source manager list when trying to `delete` a source that already exists in the deleted source list (explain in DeveloperGuide.adoc)

Resolves issue #172 #177 #173
Partially Implements #141 