### PR TITLE
Search Command: Tests, Enhancements, and Docs

### DIFF
--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -505,6 +505,11 @@ It's major usage is in the fact that the user will store the bulk of their data 
 list the entire contents of the source in order to match and search it. Thus now, the user is only required to `search` using
 as many consecutive words they are able to recall to narrow the listings.
 
+Furthermore, the search command is able to take in multiple arguments of each prefix and search
+in conjunction such as all those fields are matched with the corresponding fields of the resulting sources.
+This renders this feature more power as now the user is able to search by all that he can recall about the source
+entry and be able to narrow down his search more to produce desired results.
+
 How it works is, it allows the user to search through all the entries in the database through various fields at a time, and display
 source entries that satisfy all of the entered tags in conjunction, by checking if the source value contains these parameters.
 It allows compound searches to be made, allowing user to narrow down their search, hence helping in efficient retrieval
@@ -518,14 +523,16 @@ for those sources that satisfy all the constraints, i.e. have all the fields mat
 contains the keywords entered by the user (case insensitive).
 
 This feature improves the product significantly because a user can now search an entry with a particular title AND a particular type and so on.
-Not only that, the user can now just input whatever they are able to recall and the `search` returns all super strings instead of
-carrying out an exact matching.
+Not only that, the user can now just input whatever they are able to recall in the form of multiple prefix arguments
+and the `search` returns all super strings instead of carrying out an exact matching of just one search tag. This was implemented
+by changing all values collected from argument multimap in `SourceContainsKeywordsPredicate` to `List<String>` and `getAllValues()` instead of just `String`
+and `getValue` which used to extract the last value of the specified prefix.
 It helps user greatly narrow down their search should they be looking for a specific source entry with particular values,
 instead of cluttering the screen with all those sources with share the same title as the one the user searches using the command.
 It renders the search more powerful by resulting all super-strings should the user have meant something else or to prompt them about other similar
 source entries containing what they are looking for.
 It also allows user to search sources based on other fields and not just title, such as type, tags and details, and even their
-logical combination.
+logical combination, and multiple of them.
 
 Given below is an example usage scenario and how the search mechanism behaves at each step.
 
@@ -534,20 +541,32 @@ in an indexed fashion, with all details and in order of their addition.
 
 Step 2. The user executes `search i/footitle1` command and only those sources that have their title as `footitle1` are displayed.
 
-Step 3. The user executes `search i/footitle6 y/website` and only those entries are listed that have both their title as `footitle1` and type as `website`.
+Step 3. The user executes `search i/footitle1 y/website` and only those entries are listed that have their title having both `foo` and `6` and type as `website` will
+be enlisted.
 
 Step 4. The user executes `search t/CS` and all those sources that have any of their tags having 'CS' in it listed, including `CS2030`, `CS2040` and `CS2103`
 
+Step 5. The user executes `search i/` and 0 sources are listed because this is not a valid check. This is not a bug and is the intended
+feature.
+
 [NOTE]
-`search` alone, without any arguments, will result in error. See `list` command for enumerating all database entries.
+`search` alone, without any arguments or with empty prefix tags, will result in error and 0 listed sources respectively.
+ See `list` command for enumerating all database entries.
+
+Step 6. The user executes `search i/algo i/wiki` and all those sources with both `algo` and `wiki` in their titles, such as
+`Wikipedia Algorithm` or `Algos of wikitionary` will be listed
+
+****
+Some content here
+****
 
 ==== Design Considerations
 
 ===== Aspect: How search executes
 
-* **Alternative 1 (current choice):** Runs through all entries and matches the arguments, field by field, and uing `&&` operation
+* **Alternative 1 (current choice):** Runs through all entries and matches the arguments, field by field, and using `&&` operation
 to combine the results.
-** Pros: Easy to implement as exact String matching can be done in Java using streams and `StringUtil.containsWordIgnoreCase(str1, str2)`.
+** Pros: Easy to implement as exact String substring matching can be done in Java using `str1.contains(str2)`.
 ** Cons: May have performance issues in terms of time usage.
 
 ===== Aspect: Data structure to support the undo/redo commands

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -163,13 +163,17 @@ Able to perform substring matching.
 Finds all entries with a (case insensitive) field value that contains the value as specified by the user. +
 Searches with multiple arguments are taken as conjunction searches, i.e all those sources
 that satisfy all the keyword values are shown (logical `and` operation).
+Furthermore, the search command is able to take in multiple arguments of each prefix and search
+in conjunction such as all those fields are matched with the corresponding fields of the resulting sources.
 
-Format: `search [i/TITLE] [y/TYPE] [d/DETAILS] [t/TAG]`
+Format: `search [i/TITLE] [y/TYPE] [d/DETAILS] [t/TAG]...`
 
 ****
 * The search is case insensitive. e.g `hans` will match `Hans`
 * The search implements substring matching. e.g. `algo` will match algorithm, algorithms, algo trading, etc.
 * There can have any number of tags but minimally 1 (just `search` results in error. To enumerate all entries, check out `list` command instead)
+* There can be multiple tags with same prefix and the result must satisfy all, eg. `search i/algo i/data` will result in `data struc. and algorithms`
+because it is a super-string of both the entered field values.
 * Search implemented as a logical AND. eg. `search i/algorithm y/website` results in all those sources
 that have title `algorithm` AND type `website`
 ****
@@ -178,7 +182,7 @@ Examples:
 
 * `search i/Algorithms` +
 Returns the source(s) with the title `algorithms`
-* `search y/web d/intelligence t/ML` +
+* `search i/wiki i/algo y/web d/intelligence t/ML` +
 Returns any source having tags `ML` and having the word `intelligence` somewhere in their content
 (detail) and having a type of `website` or `web series`.
 

--- a/docs/team/ruhanisuri.adoc
+++ b/docs/team/ruhanisuri.adoc
@@ -25,11 +25,11 @@ where you read something and struggle to find it again.
 
 == Summary of contributions
 
-=== *Major enhancement*: +
+== *Major enhancement*: +
 
-===== 1. Modified *the ability to search* through sources:
+==== 1. Modified *the ability to search* through sources:
 
-====== *Previously*:
+===== *Previously*:
 
 Format: `search <title>`
 
@@ -53,15 +53,24 @@ when the user stores his entire research data in the `detail`, say 3 paragraphs,
 word to word in their entirety. This defeats the purpose of the user being able to search for a source so he can use it in his
 research.
 
-====== *Modification*:
+Furthermore, this format of search only (logically) accepted one argument for each prefix tag, that is if given multiple,
+it would jut ignore it. This was implemented by using `getValue()` on the user enter argument multimap in
+`SourceContainsKeywordsPredicate`. This method only returned the last entered values and used this for the search command logic, ignore
+other tags.
+
+===== *Modification*:
 
 Format: `search [n/TITLE] [y/TYPE] [d/DETAILS] [t/TAG] [t/TAG]...`
 
+The work I have done on AB4's search feature can be divided into 3 major modifications as follows:
+
+===== 1. Multiple prefix tags of different kinds:
 In the implementation of The Infinity Machine, search function now has an added functionality of being able to take in multiple
 arguments of the type of source fields, and search for sources based on that.
 It searches in conjunction using multiple fields including title, type, detail and tag(s) input by the user,
 listing only those sources that satisfy all the input constraints of the matching fields.
 
+===== 2. Substring matching with incomplete words:
 Another addition to its functionality is that this search feature is enabled with substring matching as against exact field matching.
 This renders this feature more powerful as the user may not always be able to remember exactly the title or tag of the source.
 It's major usage is in the fact that the user will store the bulk of their data in the details field, and it is unintuitive to have them
@@ -69,24 +78,31 @@ list the entire contents of the source in order to match and search it. Thus now
 as many consecutive words they are able to recall to narrow the listings. Eg. searching for `d/Artificial Intelligence` will
 enumerate all source articles that have 'artificial intelligence' in their content.
 
-====== *What it does*:
-It allows the user to search through all the entries in the database through various fields at a time, and display
-source entries that satisfy all of the entered tags in conjunction, with substring matching.
-It allows compound searches to be made, allowing user to narrow down their search, hence helping in efficient retrieval
-of the sources, and making working on the database more efficient. It also checks if the source fields contain the keywords entered
-by the user.
+===== 3. Multiple prefix tags of one type:
+Furthermore, the search command is able to take in multiple arguments of each prefix and search
+in conjunction such as all those fields are matched with the corresponding fields of the resulting sources.
+This renders this feature more power as now the user is able to search by all that he can recall about the source
+entry and be able to narrow down his search more to produce desired results.
 
-====== *Justification*:
+===== *What it does*:
+It allows the user to search through all the entries in the database through various fields at a time, and display
+source entries that satisfy all of the entered tags in conjunction, with substring matching, and allowing multiple tags of
+the same kind.
+It allows compound searches to be made, allowing user to narrow down their search, hence helping in efficient retrieval
+of the sources, and making working on the database more efficient. It also reduces the onus on the user to remember and recall
+the source entries maintained by allowing them to enter as many consecutive characters for a field value they can enumerate.
+
+===== *Justification*:
 This feature improves the product significantly because a user can now search an entry with a particular title AND a particular type and so on.
-Furthermore, it removes the reliance on the user to memorize exact field values, by enabling substring matching so the user can enter as much as
-he remembers and see the results.
+Furthermore, it removes the reliance on the user to memorize exact field values, by enabling substring matching and multiple tags
+entered so the user can enter as much as he remembers and see the results.
 
 It helps user greatly narrow down their search should they be looking for a specific source entry with particular values,
 instead of cluttering the screen with all those sources with share the same title as the one the user searches using the command.
 It also allows user to search sources based on other fields and not just title, such as type, tags and details, and even their
 logical combination, along with allowing the user to not memorize his source fields.
 
-====== *Highlights*:
+===== *Highlights*:
 
 - This enhancement does not affect existing commands and commands to be added in future. +
 - However, it changed the format of the original `search` command, which now not only takes parameters of different types, but also needs them to be prefixed by their
@@ -94,13 +110,17 @@ CLI delimiters.
 - It required an in-depth analysis of design alternatives, as the format of the original command had to be changed
 - The implementation too was challenging, as the current format of `search` command had to be changed and be prepared to
 accept and parse multiple fields entered.
-- Its was also tricky to implement the conjunction of the fields as separate methods had to be written for checking for the presence
+- It was also tricky to implement the conjunction of the fields as separate methods had to be written for checking for the presence
 of each of the field entered and by logical `&&` ing their results.
+- It was also tricky to implement multiple same prefix tags to be accepted as all values collected from argument multimap in `SourceContainsKeywordsPredicate` had to be changed
+from `String` from `getValue` which was used to extract the last value of the specified prefix to `List<String>` from `getAllValues()` which
+extracted argument values of all tags entered by the user without ignoring any. Then the checker methods had to be
+modified to implement an `AND` logic to ensure all these search queries are satisfied.
 - It was relatively simple to change exact matching to substring matching by using `String.contains()` method.
 - It was trivial to implement case insensitivity by converting both source value and argument value `toLowerCase()` before carrying
 out the substring comparison.
 
-====== *Credits*:
+===== *Credits*:
 Most of the feature was developed independently, with some design and implementation considerations discussed with fellow team members.
 
 === *Minor enhancement*:

--- a/src/main/java/seedu/address/logic/commands/SearchCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SearchCommand.java
@@ -56,4 +56,9 @@ public class SearchCommand extends Command {
                 || (other instanceof SearchCommand // instanceof handles nulls
                 && predicate.equals(((SearchCommand) other).predicate)); // state check
     }
+
+    @Override
+    public int hashCode() {
+        return predicate.hashCode();
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -1,10 +1,5 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DETAILS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -67,15 +62,12 @@ public class ArgumentMultimap {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof ArgumentMultimap // instanceof handles nulls
-                    && (this.getPreamble().equals(((ArgumentMultimap) other).getPreamble()))
-                    && (this.getAllValues(PREFIX_TITLE).equals(((ArgumentMultimap) other)
-                        .getAllValues(PREFIX_TITLE)))
-                    && (this.getAllValues(PREFIX_TYPE).equals(((ArgumentMultimap) other)
-                        .getAllValues(PREFIX_TYPE)))
-                    && (this.getAllValues(PREFIX_DETAILS).equals(((ArgumentMultimap) other)
-                        .getAllValues(PREFIX_DETAILS)))
-                    && (this.getAllValues(PREFIX_TAG).equals(((ArgumentMultimap) other)
-                        .getAllValues(PREFIX_TAG)))
+                    && (this.argMultimap.equals(((ArgumentMultimap) other).argMultimap))
                     ); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return argMultimap.hashCode();
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static seedu.address.logic.parser.CliSyntax.*;
+
 /**
  * Stores mapping of prefixes to their respective arguments.
  * Each key may be associated with multiple argument values.
@@ -56,5 +58,17 @@ public class ArgumentMultimap {
      */
     public String getPreamble() {
         return getValue(new Prefix("")).orElse("");
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ArgumentMultimap // instanceof handles nulls
+                && (this.getPreamble().equals(((ArgumentMultimap) other).getPreamble()))
+                && (this.getAllValues(PREFIX_TITLE).equals(((ArgumentMultimap) other).getAllValues(PREFIX_TITLE)))
+                && (this.getAllValues(PREFIX_TYPE).equals(((ArgumentMultimap) other).getAllValues(PREFIX_TYPE)))
+                && (this.getAllValues(PREFIX_DETAILS).equals(((ArgumentMultimap) other).getAllValues(PREFIX_DETAILS)))
+                && (this.getAllValues(PREFIX_TAG).equals(((ArgumentMultimap) other).getAllValues(PREFIX_TAG)))
+        ); // state check
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -1,12 +1,15 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DETAILS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
-import static seedu.address.logic.parser.CliSyntax.*;
 
 /**
  * Stores mapping of prefixes to their respective arguments.
@@ -64,11 +67,15 @@ public class ArgumentMultimap {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof ArgumentMultimap // instanceof handles nulls
-                && (this.getPreamble().equals(((ArgumentMultimap) other).getPreamble()))
-                && (this.getAllValues(PREFIX_TITLE).equals(((ArgumentMultimap) other).getAllValues(PREFIX_TITLE)))
-                && (this.getAllValues(PREFIX_TYPE).equals(((ArgumentMultimap) other).getAllValues(PREFIX_TYPE)))
-                && (this.getAllValues(PREFIX_DETAILS).equals(((ArgumentMultimap) other).getAllValues(PREFIX_DETAILS)))
-                && (this.getAllValues(PREFIX_TAG).equals(((ArgumentMultimap) other).getAllValues(PREFIX_TAG)))
-        ); // state check
+                    && (this.getPreamble().equals(((ArgumentMultimap) other).getPreamble()))
+                    && (this.getAllValues(PREFIX_TITLE).equals(((ArgumentMultimap) other)
+                        .getAllValues(PREFIX_TITLE)))
+                    && (this.getAllValues(PREFIX_TYPE).equals(((ArgumentMultimap) other)
+                        .getAllValues(PREFIX_TYPE)))
+                    && (this.getAllValues(PREFIX_DETAILS).equals(((ArgumentMultimap) other)
+                        .getAllValues(PREFIX_DETAILS)))
+                    && (this.getAllValues(PREFIX_TAG).equals(((ArgumentMultimap) other)
+                        .getAllValues(PREFIX_TAG)))
+                    ); // state check
     }
 }

--- a/src/main/java/seedu/address/logic/parser/SearchCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SearchCommandParser.java
@@ -31,10 +31,10 @@ public class SearchCommandParser implements Parser<SearchCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_TITLE, PREFIX_TYPE, PREFIX_DETAILS, PREFIX_TAG);
 
         if (!argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SearchCommand.MESSAGE_USAGE));
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, SearchCommand.MESSAGE_USAGE));
         }
 
-        //String[] titleKeywords = trimmedArgs.split("\\s+");
         return new SearchCommand(new SourceContainsKeywordsPredicate(argMultimap));
     }
 

--- a/src/main/java/seedu/address/model/source/SourceContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/source/SourceContainsKeywordsPredicate.java
@@ -133,4 +133,9 @@ public class SourceContainsKeywordsPredicate implements Predicate<Source> {
                 || (other instanceof SourceContainsKeywordsPredicate // instanceof handles nulls
                 && keywords.equals(((SourceContainsKeywordsPredicate) other).keywords)); // state check
     }
+
+    @Override
+    public int hashCode() {
+        return keywords.hashCode();
+    }
 }

--- a/src/main/java/seedu/address/model/source/SourceContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/source/SourceContainsKeywordsPredicate.java
@@ -28,33 +28,31 @@ public class SourceContainsKeywordsPredicate implements Predicate<Source> {
     public boolean test(Source source) {
         boolean result = true;
 
-        String titleKeywords = keywords.getValue(PREFIX_TITLE).orElse("");
-        String typeKeywords = keywords.getValue(PREFIX_TYPE).orElse("");
-        String detailsKeywords = keywords.getValue(PREFIX_DETAILS).orElse("");
+        List<String> titleKeywords = keywords.getAllValues(PREFIX_TITLE);
+        List<String> typeKeywords = keywords.getAllValues(PREFIX_TYPE);
+        List<String> detailsKeywords = keywords.getAllValues(PREFIX_DETAILS);
         List<String> tagKeywords = keywords.getAllValues(PREFIX_TAG);
 
-        if (titleKeywords.equals("") && (tagKeywords.isEmpty() || checkAllEmpty(tagKeywords))
-                && typeKeywords.equals("") && detailsKeywords.equals("")) {
+        if ((titleKeywords.isEmpty() || checkAllEmpty(titleKeywords))
+                && (typeKeywords.isEmpty() || checkAllEmpty(typeKeywords))
+                && (detailsKeywords.isEmpty() || checkAllEmpty(detailsKeywords))
+                && (tagKeywords.isEmpty() || checkAllEmpty(tagKeywords))) {
             return false;
         }
 
-        if (!titleKeywords.equals("")) {
+        if (!titleKeywords.isEmpty() && !checkAllEmpty(titleKeywords)) {
             result = result && matchTitleKeywords(titleKeywords, source);
         }
 
-        if (!typeKeywords.equals("")) {
+        if (!typeKeywords.isEmpty() && !checkAllEmpty(typeKeywords)) {
             result = result && matchTypeKeywords(typeKeywords, source);
         }
 
-        if (!detailsKeywords.equals("")) {
+        if (!detailsKeywords.isEmpty() && !checkAllEmpty(detailsKeywords)) {
             result = result && matchDetailKeywords(detailsKeywords, source);
         }
 
         if (!tagKeywords.isEmpty() && !checkAllEmpty(tagKeywords)) {
-            List<String> listTitleKeywords = new ArrayList<>();
-            for (String tag : tagKeywords) {
-                listTitleKeywords.add(tag.trim());
-            }
             result = result && matchTagKeywords(tagKeywords, source);
         }
 
@@ -67,11 +65,9 @@ public class SourceContainsKeywordsPredicate implements Predicate<Source> {
      */
     public boolean checkAllEmpty(List<String> keywords) {
         boolean result = true;
-
         for (String s : keywords) {
             result = result && s.equals("");
         }
-
         return result;
     }
 
@@ -97,10 +93,12 @@ public class SourceContainsKeywordsPredicate implements Predicate<Source> {
      * @param source to be tested
      * @return true if matches, else false
      */
-    private boolean matchDetailKeywords(String detailsKeywords, Source source) {
-        List<String> listDetailKeywords = Arrays.asList(detailsKeywords.trim().split("\\s+"));
-        return listDetailKeywords.stream()
-                .anyMatch(keyword -> (source.getDetail().detail.toLowerCase().contains(keyword.toLowerCase())));
+    private boolean matchDetailKeywords(List<String> detailsKeywords, Source source) {
+        boolean result = true;
+        for (String detail : detailsKeywords) {
+            result = result && (source.getDetail().detail.toLowerCase().contains(detail.toLowerCase()));
+        }
+        return result;
     }
 
     /**
@@ -109,10 +107,12 @@ public class SourceContainsKeywordsPredicate implements Predicate<Source> {
      * @param source to be tested
      * @return true if matches, else false
      */
-    private boolean matchTypeKeywords(String typeKeywords, Source source) {
-        List<String> listTypeKeywords = Arrays.asList(typeKeywords.trim().split("\\s+"));
-        return listTypeKeywords.stream()
-                .anyMatch(keyword -> (source.getType().type.toLowerCase()).contains(keyword.toLowerCase()));
+    private boolean matchTypeKeywords(List<String> typeKeywords, Source source) {
+        boolean result = true;
+        for (String type : typeKeywords) {
+            result = result && (source.getType().type.toLowerCase().contains(type.toLowerCase()));
+        }
+        return result;
     }
 
     /**
@@ -121,10 +121,12 @@ public class SourceContainsKeywordsPredicate implements Predicate<Source> {
      * @param source to be tested
      * @return true if matches, else false
      */
-    private boolean matchTitleKeywords(String titleKeywords, Source source) {
-        List<String> listTitleKeywords = Arrays.asList(titleKeywords.trim().split("\\s+"));
-        return listTitleKeywords.stream()
-                .anyMatch(keyword -> (source.getTitle().title.toLowerCase()).contains(keyword.toLowerCase()));
+    private boolean matchTitleKeywords(List<String> titleKeywords, Source source) {
+        boolean result = true;
+        for (String title : titleKeywords) {
+            result = result && (source.getTitle().title.toLowerCase().contains(title.toLowerCase()));
+        }
+        return result;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/source/SourceContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/source/SourceContainsKeywordsPredicate.java
@@ -5,8 +5,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
 

--- a/src/main/java/seedu/address/model/source/SourceContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/source/SourceContainsKeywordsPredicate.java
@@ -33,7 +33,7 @@ public class SourceContainsKeywordsPredicate implements Predicate<Source> {
         String detailsKeywords = keywords.getValue(PREFIX_DETAILS).orElse("");
         List<String> tagKeywords = keywords.getAllValues(PREFIX_TAG);
 
-        if (titleKeywords.equals("") && tagKeywords.isEmpty()
+        if (titleKeywords.equals("") && (tagKeywords.isEmpty() || checkAllEmpty(tagKeywords))
                 && typeKeywords.equals("") && detailsKeywords.equals("")) {
             return false;
         }
@@ -50,12 +50,26 @@ public class SourceContainsKeywordsPredicate implements Predicate<Source> {
             result = result && matchDetailKeywords(detailsKeywords, source);
         }
 
-        if (!tagKeywords.isEmpty()) {
+        if (!tagKeywords.isEmpty() && !checkAllEmpty(tagKeywords)) {
             List<String> listTitleKeywords = new ArrayList<>();
             for (String tag : tagKeywords) {
                 listTitleKeywords.add(tag.trim());
             }
             result = result && matchTagKeywords(tagKeywords, source);
+        }
+
+        return result;
+    }
+
+    /**
+     * Evaluates true if all of the entries in a list of strings is empty
+     *
+     */
+    public boolean checkAllEmpty(List<String> keywords) {
+        boolean result = true;
+
+        for (String s : keywords) {
+            result = result && s.equals("");
         }
 
         return result;
@@ -72,7 +86,7 @@ public class SourceContainsKeywordsPredicate implements Predicate<Source> {
         boolean result = true;
         for (String tag : tagKeywords) {
             result = result && source.getTags().stream()
-                    .anyMatch(keyword -> (keyword.tagName.toLowerCase()).contains(tag.trim().toLowerCase()));
+                    .anyMatch(keyword -> (keyword.tagName.trim().toLowerCase()).contains(tag.trim().toLowerCase()));
         }
         return result;
     }

--- a/src/test/java/seedu/address/logic/commands/SearchCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SearchCommandTest.java
@@ -22,8 +22,7 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.source.SourceContainsKeywordsPredicate;
 
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.*;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code SearchCommand}.
@@ -75,7 +74,11 @@ public class SearchCommandTest {
     public void execute_zeroTitleKeywords_noSourceFound() {
 
         String expectedMessage = String.format(MESSAGE_SOURCES_LISTED_OVERVIEW, 0);
-        SourceContainsKeywordsPredicate predicate = preparePredicate(PREFIX_TITLE, "");
+        ArrayList<Prefix> pList = new ArrayList<>();
+        ArrayList<String> sList = new ArrayList<>();
+        pList.add(PREFIX_TITLE);
+        sList.add("");
+        SourceContainsKeywordsPredicate predicate = preparePredicate(pList, sList);
         SearchCommand command = new SearchCommand(predicate);
         expectedModel.updateFilteredSourceList(predicate);
         assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
@@ -87,7 +90,11 @@ public class SearchCommandTest {
     public void execute_zeroTypeKeywords_noSourceFound() {
 
         String expectedMessage = String.format(MESSAGE_SOURCES_LISTED_OVERVIEW, 0);
-        SourceContainsKeywordsPredicate predicate = preparePredicate(PREFIX_TYPE, "");
+        ArrayList<Prefix> pList = new ArrayList<>();
+        ArrayList<String> sList = new ArrayList<>();
+        pList.add(PREFIX_TYPE);
+        sList.add("");
+        SourceContainsKeywordsPredicate predicate = preparePredicate(pList, sList);
         SearchCommand command = new SearchCommand(predicate);
         expectedModel.updateFilteredSourceList(predicate);
         assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
@@ -99,7 +106,11 @@ public class SearchCommandTest {
     public void execute_zeroDetailKeywords_noSourceFound() {
 
         String expectedMessage = String.format(MESSAGE_SOURCES_LISTED_OVERVIEW, 0);
-        SourceContainsKeywordsPredicate predicate = preparePredicate(PREFIX_DETAILS, "");
+        ArrayList<Prefix> pList = new ArrayList<>();
+        ArrayList<String> sList = new ArrayList<>();
+        pList.add(PREFIX_DETAILS);
+        sList.add("");
+        SourceContainsKeywordsPredicate predicate = preparePredicate(pList, sList);
         SearchCommand command = new SearchCommand(predicate);
         expectedModel.updateFilteredSourceList(predicate);
         assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
@@ -111,7 +122,11 @@ public class SearchCommandTest {
     public void execute_zeroTagKeywords_noSourceFound() {
 
         String expectedMessage = String.format(MESSAGE_SOURCES_LISTED_OVERVIEW, 0);
-        SourceContainsKeywordsPredicate predicate = preparePredicate(PREFIX_TAG, "");
+        ArrayList<Prefix> pList = new ArrayList<>();
+        ArrayList<String> sList = new ArrayList<>();
+        pList.add(PREFIX_TAG);
+        sList.add("");
+        SourceContainsKeywordsPredicate predicate = preparePredicate(pList, sList);
         SearchCommand command = new SearchCommand(predicate);
         expectedModel.updateFilteredSourceList(predicate);
         assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
@@ -123,7 +138,11 @@ public class SearchCommandTest {
     public void execute_oneTitleKeyword_multipleSourcesFound() {
 
         String expectedMessage = String.format(MESSAGE_SOURCES_LISTED_OVERVIEW, 1);
-        SourceContainsKeywordsPredicate predicate = preparePredicate(PREFIX_TITLE,"Kurz");
+        ArrayList<Prefix> pList = new ArrayList<>();
+        ArrayList<String> sList = new ArrayList<>();
+        pList.add(PREFIX_TITLE);
+        sList.add("Kurz");
+        SourceContainsKeywordsPredicate predicate = preparePredicate(pList, sList);
         SearchCommand command = new SearchCommand(predicate);
         expectedModel.updateFilteredSourceList(predicate);
         assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
@@ -135,7 +154,11 @@ public class SearchCommandTest {
     public void execute_oneTypeKeyword_multipleSourcesFound() {
 
         String expectedMessage = String.format(MESSAGE_SOURCES_LISTED_OVERVIEW, 1);
-        SourceContainsKeywordsPredicate predicate = preparePredicate(PREFIX_TYPE,"carl");
+        ArrayList<Prefix> pList = new ArrayList<>();
+        ArrayList<String> sList = new ArrayList<>();
+        pList.add(PREFIX_TYPE);
+        sList.add("carl type");
+        SourceContainsKeywordsPredicate predicate = preparePredicate(pList, sList);
         SearchCommand command = new SearchCommand(predicate);
         expectedModel.updateFilteredSourceList(predicate);
         assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
@@ -147,7 +170,11 @@ public class SearchCommandTest {
     public void execute_oneDetailKeyword_multipleSourcesFound() {
 
         String expectedMessage = String.format(MESSAGE_SOURCES_LISTED_OVERVIEW, 1);
-        SourceContainsKeywordsPredicate predicate = preparePredicate(PREFIX_DETAILS,"carl_detail");
+        ArrayList<Prefix> pList = new ArrayList<>();
+        ArrayList<String> sList = new ArrayList<>();
+        pList.add(PREFIX_DETAILS);
+        sList.add("carl_detail");
+        SourceContainsKeywordsPredicate predicate = preparePredicate(pList, sList);
         SearchCommand command = new SearchCommand(predicate);
         expectedModel.updateFilteredSourceList(predicate);
         assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
@@ -159,21 +186,101 @@ public class SearchCommandTest {
     public void execute_oneTagKeyword_multipleSourcesFound() {
 
         String expectedMessage = String.format(MESSAGE_SOURCES_LISTED_OVERVIEW, 3);
-        SourceContainsKeywordsPredicate predicate = preparePredicate(PREFIX_TITLE,"Kurz Elle Kunz");
+        ArrayList<Prefix> pList = new ArrayList<>();
+        ArrayList<String> sList = new ArrayList<>();
+        pList.add(PREFIX_TAG);
+        sList.add("friend");
+        SourceContainsKeywordsPredicate predicate = preparePredicate(pList, sList);
         SearchCommand command = new SearchCommand(predicate);
         expectedModel.updateFilteredSourceList(predicate);
         assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredSourceList());
+        assertEquals(Arrays.asList(ALICE, BENSON, DANIEL), model.getFilteredSourceList());
+
+    }
+
+    @Test
+    public void execute_multipleTitleKeywords_multipleSourcesFound() {
+
+        String expectedMessage = String.format(MESSAGE_SOURCES_LISTED_OVERVIEW, 1);
+        ArrayList<Prefix> pList = new ArrayList<>();
+        ArrayList<String> sList = new ArrayList<>();
+        pList.add(PREFIX_TITLE);
+        pList.add(PREFIX_TITLE);
+        sList.add("alice");
+        sList.add("paul");
+        SourceContainsKeywordsPredicate predicate = preparePredicate(pList, sList);
+        SearchCommand command = new SearchCommand(predicate);
+        expectedModel.updateFilteredSourceList(predicate);
+        assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ALICE), model.getFilteredSourceList());
+
+    }
+
+    @Test
+    public void execute_multipleTypeKeywords_multipleSourcesFound() {
+
+        String expectedMessage = String.format(MESSAGE_SOURCES_LISTED_OVERVIEW, 0);
+        ArrayList<Prefix> pList = new ArrayList<>();
+        ArrayList<String> sList = new ArrayList<>();
+        pList.add(PREFIX_TYPE);
+        pList.add(PREFIX_TYPE);
+        sList.add("alice");
+        sList.add("ben");
+        SourceContainsKeywordsPredicate predicate = preparePredicate(pList, sList);
+        SearchCommand command = new SearchCommand(predicate);
+        expectedModel.updateFilteredSourceList(predicate);
+        assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredSourceList());
+
+    }
+
+    @Test
+    public void execute_multipleDetailKeywords_multipleSourcesFound() {
+
+        String expectedMessage = String.format(MESSAGE_SOURCES_LISTED_OVERVIEW, 3);
+        ArrayList<Prefix> pList = new ArrayList<>();
+        ArrayList<String> sList = new ArrayList<>();
+        pList.add(PREFIX_DETAILS);
+        pList.add(PREFIX_DETAILS);
+        sList.add("e_detail");
+        sList.add("e_detail");
+        SourceContainsKeywordsPredicate predicate = preparePredicate(pList, sList);
+        SearchCommand command = new SearchCommand(predicate);
+        expectedModel.updateFilteredSourceList(predicate);
+        assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ALICE, ELLE, GEORGE), model.getFilteredSourceList());
+
+    }
+
+    @Test
+    public void execute_multipleTagKeywords_multipleSourcesFound() {
+
+        String expectedMessage = String.format(MESSAGE_SOURCES_LISTED_OVERVIEW, 3);
+        ArrayList<Prefix> pList = new ArrayList<>();
+        ArrayList<String> sList = new ArrayList<>();
+        pList.add(PREFIX_TAG);
+        pList.add(PREFIX_TAG);
+        sList.add("friend");
+        sList.add("end");
+        SourceContainsKeywordsPredicate predicate = preparePredicate(pList, sList);
+        SearchCommand command = new SearchCommand(predicate);
+        expectedModel.updateFilteredSourceList(predicate);
+        assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ALICE, BENSON, DANIEL), model.getFilteredSourceList());
 
     }
 
     /**
      * Parses {@code userInput} into a {@code SourceContainsKeywordsPredicate}.
      */
-    private SourceContainsKeywordsPredicate preparePredicate(Prefix prefix, String userInput) {
+    private SourceContainsKeywordsPredicate preparePredicate(ArrayList<Prefix> prefix, ArrayList<String> userInput) {
+        assert prefix.size() == userInput.size();
         ArgumentMultimap argMultimap = new ArgumentMultimap();
-        argMultimap.put(prefix, userInput);
+        Iterator<Prefix> pIter = prefix.iterator();
+        Iterator<String> sIter = userInput.iterator();
+        while (pIter.hasNext() && sIter.hasNext()) {
+            argMultimap.put(pIter.next(), sIter.next());
+        }
         return new SourceContainsKeywordsPredicate(argMultimap);
-        //return new SourceContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/SearchCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SearchCommandTest.java
@@ -242,8 +242,12 @@ public class SearchCommandTest {
         ArrayList<String> sList = new ArrayList<>();
         pList.add(PREFIX_DETAILS);
         pList.add(PREFIX_DETAILS);
+        pList.add(PREFIX_DETAILS);
+        pList.add(PREFIX_DETAILS);
         sList.add("e_detail");
         sList.add("e_detail");
+        sList.add("tail");
+        sList.add("eta");
         SourceContainsKeywordsPredicate predicate = preparePredicate(pList, sList);
         SearchCommand command = new SearchCommand(predicate);
         expectedModel.updateFilteredSourceList(predicate);
@@ -260,13 +264,37 @@ public class SearchCommandTest {
         ArrayList<String> sList = new ArrayList<>();
         pList.add(PREFIX_TAG);
         pList.add(PREFIX_TAG);
+        pList.add(PREFIX_TAG);
         sList.add("friend");
         sList.add("end");
+        sList.add("fri");
         SourceContainsKeywordsPredicate predicate = preparePredicate(pList, sList);
         SearchCommand command = new SearchCommand(predicate);
         expectedModel.updateFilteredSourceList(predicate);
         assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(ALICE, BENSON, DANIEL), model.getFilteredSourceList());
+
+    }
+
+    @Test
+    public void execute_multipleCompoundKeywords_multipleSourcesFound() {
+
+        String expectedMessage = String.format(MESSAGE_SOURCES_LISTED_OVERVIEW, 1);
+        ArrayList<Prefix> pList = new ArrayList<>();
+        ArrayList<String> sList = new ArrayList<>();
+        pList.add(PREFIX_TITLE);
+        pList.add(PREFIX_TYPE);
+        pList.add(PREFIX_DETAILS);
+        pList.add(PREFIX_TAG);
+        sList.add("alice");
+        sList.add("");
+        sList.add("_detail");
+        sList.add("end");
+        SourceContainsKeywordsPredicate predicate = preparePredicate(pList, sList);
+        SearchCommand command = new SearchCommand(predicate);
+        expectedModel.updateFilteredSourceList(predicate);
+        assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ALICE), model.getFilteredSourceList());
 
     }
 

--- a/src/test/java/seedu/address/logic/commands/SearchCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SearchCommandTest.java
@@ -120,7 +120,43 @@ public class SearchCommandTest {
     }
 
     @Test
-    public void execute_multipleKeywords_multipleSourcesFound() {
+    public void execute_oneTitleKeyword_multipleSourcesFound() {
+
+        String expectedMessage = String.format(MESSAGE_SOURCES_LISTED_OVERVIEW, 1);
+        SourceContainsKeywordsPredicate predicate = preparePredicate(PREFIX_TITLE,"Kurz");
+        SearchCommand command = new SearchCommand(predicate);
+        expectedModel.updateFilteredSourceList(predicate);
+        assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(CARL), model.getFilteredSourceList());
+
+    }
+
+    @Test
+    public void execute_oneTypeKeyword_multipleSourcesFound() {
+
+        String expectedMessage = String.format(MESSAGE_SOURCES_LISTED_OVERVIEW, 1);
+        SourceContainsKeywordsPredicate predicate = preparePredicate(PREFIX_TYPE,"carl");
+        SearchCommand command = new SearchCommand(predicate);
+        expectedModel.updateFilteredSourceList(predicate);
+        assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(CARL), model.getFilteredSourceList());
+
+    }
+
+    @Test
+    public void execute_oneDetailKeyword_multipleSourcesFound() {
+
+        String expectedMessage = String.format(MESSAGE_SOURCES_LISTED_OVERVIEW, 1);
+        SourceContainsKeywordsPredicate predicate = preparePredicate(PREFIX_DETAILS,"carl_detail");
+        SearchCommand command = new SearchCommand(predicate);
+        expectedModel.updateFilteredSourceList(predicate);
+        assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(CARL), model.getFilteredSourceList());
+
+    }
+
+    @Test
+    public void execute_oneTagKeyword_multipleSourcesFound() {
 
         String expectedMessage = String.format(MESSAGE_SOURCES_LISTED_OVERVIEW, 3);
         SourceContainsKeywordsPredicate predicate = preparePredicate(PREFIX_TITLE,"Kurz Elle Kunz");

--- a/src/test/java/seedu/address/logic/commands/SearchCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SearchCommandTest.java
@@ -49,10 +49,10 @@ public class SearchCommandTest {
     public void equals() {
 
         ArgumentMultimap first = new ArgumentMultimap();
-        first.put(new Prefix("first"), "");
+        first.put(PREFIX_TITLE, "");
 
         ArgumentMultimap second = new ArgumentMultimap();
-        second.put(new Prefix("second"), "");
+        second.put(PREFIX_TYPE, "");
 
         SourceContainsKeywordsPredicate firstPredicate =
                 new SourceContainsKeywordsPredicate(first);

--- a/src/test/java/seedu/address/logic/commands/SearchCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SearchCommandTest.java
@@ -1,88 +1,142 @@
 package seedu.address.logic.commands;
 
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.commons.core.Messages.MESSAGE_SOURCES_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DETAILS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
+import static seedu.address.testutil.TypicalSources.*;
+
 import org.junit.Test;
 
+import seedu.address.logic.CommandHistory;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.Prefix;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
 import seedu.address.model.source.SourceContainsKeywordsPredicate;
+
+import java.util.Arrays;
+import java.util.Collections;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code SearchCommand}.
  */
 public class SearchCommandTest {
-    /*
+
     private Model model = new ModelManager(getTypicalSourceManager(), new UserPrefs(), getTypicalDeletedSources());
     private Model expectedModel = new ModelManager(getTypicalSourceManager(), new UserPrefs(),
             getTypicalDeletedSources());
     private CommandHistory commandHistory = new CommandHistory();
-    */
+
 
     @Test
     public void equals() {
-        /*
 
-//        ArgumentMultimap first = new ArgumentMultimap();
-//        first.put(new Prefix("first"), "");
-//
-//        ArgumentMultimap second = new ArgumentMultimap();
-//        second.put(new Prefix("second"), "");
-//
-//        SourceContainsKeywordsPredicate firstPredicate =
-//                new SourceContainsKeywordsPredicate(first);
-//        SourceContainsKeywordsPredicate secondPredicate =
-//                new SourceContainsKeywordsPredicate(second);
-//
-//        SearchCommand searchFirstCommand = new SearchCommand(firstPredicate);
-//        SearchCommand searchSecondCommand = new SearchCommand(secondPredicate);
-//
-//        // same object -> returns true
-//        assertTrue(searchFirstCommand.equals(searchFirstCommand));
-//
-//        // same values -> returns true
-//        SearchCommand searchFirstCommandCopy = new SearchCommand(firstPredicate);
-//        assertTrue(searchFirstCommand.equals(searchFirstCommandCopy));
-//
-//        // different types -> returns false
-//        assertFalse(searchFirstCommand.equals(1));
-//
-//        // null -> returns false
-//        assertFalse(searchFirstCommand.equals(null));
-//
-//        // different source -> returns false
-//        assertFalse(searchFirstCommand.equals(searchSecondCommand));
-        */
+        ArgumentMultimap first = new ArgumentMultimap();
+        first.put(new Prefix("first"), "");
+
+        ArgumentMultimap second = new ArgumentMultimap();
+        second.put(new Prefix("second"), "");
+
+        SourceContainsKeywordsPredicate firstPredicate =
+                new SourceContainsKeywordsPredicate(first);
+        SourceContainsKeywordsPredicate secondPredicate =
+                new SourceContainsKeywordsPredicate(second);
+
+        SearchCommand searchFirstCommand = new SearchCommand(firstPredicate);
+        SearchCommand searchSecondCommand = new SearchCommand(secondPredicate);
+
+        // same object -> returns true
+        assertTrue(searchFirstCommand.equals(searchFirstCommand));
+
+        // same values -> returns true
+        SearchCommand searchFirstCommandCopy = new SearchCommand(firstPredicate);
+        assertTrue(searchFirstCommand.equals(searchFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(searchFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(searchFirstCommand.equals(null));
+
+        // different source -> returns false
+        assertFalse(searchFirstCommand.equals(searchSecondCommand));
+
     }
 
     @Test
-    public void execute_zeroKeywords_noSourceFound() {
-        /*
-//        String expectedMessage = String.format(MESSAGE_SOURCES_LISTED_OVERVIEW, 0);
-//        SourceContainsKeywordsPredicate predicate = preparePredicate(" ");
-//        SearchCommand command = new SearchCommand(predicate);
-//        expectedModel.updateFilteredSourceList(predicate);
-//        assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
-//        assertEquals(Collections.emptyList(), model.getFilteredSourceList());
-        */
+    public void execute_zeroTitleKeywords_noSourceFound() {
+
+        String expectedMessage = String.format(MESSAGE_SOURCES_LISTED_OVERVIEW, 0);
+        SourceContainsKeywordsPredicate predicate = preparePredicate(PREFIX_TITLE, "");
+        SearchCommand command = new SearchCommand(predicate);
+        expectedModel.updateFilteredSourceList(predicate);
+        assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredSourceList());
+
+    }
+
+    @Test
+    public void execute_zeroTypeKeywords_noSourceFound() {
+
+        String expectedMessage = String.format(MESSAGE_SOURCES_LISTED_OVERVIEW, 0);
+        SourceContainsKeywordsPredicate predicate = preparePredicate(PREFIX_TYPE, "");
+        SearchCommand command = new SearchCommand(predicate);
+        expectedModel.updateFilteredSourceList(predicate);
+        assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredSourceList());
+
+    }
+
+    @Test
+    public void execute_zeroDetailKeywords_noSourceFound() {
+
+        String expectedMessage = String.format(MESSAGE_SOURCES_LISTED_OVERVIEW, 0);
+        SourceContainsKeywordsPredicate predicate = preparePredicate(PREFIX_DETAILS, "");
+        SearchCommand command = new SearchCommand(predicate);
+        expectedModel.updateFilteredSourceList(predicate);
+        assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredSourceList());
+
+    }
+
+    @Test
+    public void execute_zeroTagKeywords_noSourceFound() {
+
+        String expectedMessage = String.format(MESSAGE_SOURCES_LISTED_OVERVIEW, 0);
+        SourceContainsKeywordsPredicate predicate = preparePredicate(PREFIX_TAG, "");
+        SearchCommand command = new SearchCommand(predicate);
+        expectedModel.updateFilteredSourceList(predicate);
+        assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredSourceList());
+
     }
 
     @Test
     public void execute_multipleKeywords_multipleSourcesFound() {
-        /*
+
         String expectedMessage = String.format(MESSAGE_SOURCES_LISTED_OVERVIEW, 3);
-        SourceContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
+        SourceContainsKeywordsPredicate predicate = preparePredicate(PREFIX_TITLE,"Kurz Elle Kunz");
         SearchCommand command = new SearchCommand(predicate);
         expectedModel.updateFilteredSourceList(predicate);
         assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredSourceList());
-        */
+
     }
 
     /**
-     * Parses {@code userInput} into a {@code TitleContainsKeywordsPredicate}.
+     * Parses {@code userInput} into a {@code SourceContainsKeywordsPredicate}.
      */
-    private SourceContainsKeywordsPredicate preparePredicate(String userInput) {
+    private SourceContainsKeywordsPredicate preparePredicate(Prefix prefix, String userInput) {
         ArgumentMultimap argMultimap = new ArgumentMultimap();
-        argMultimap.put(new Prefix("i/"), userInput);
+        argMultimap.put(prefix, userInput);
         return new SourceContainsKeywordsPredicate(argMultimap);
         //return new SourceContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
     }

--- a/src/test/java/seedu/address/logic/commands/SearchCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SearchCommandTest.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.commands;
 
-
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -10,7 +9,19 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_DETAILS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
-import static seedu.address.testutil.TypicalSources.*;
+import static seedu.address.testutil.TypicalSources.ALICE;
+import static seedu.address.testutil.TypicalSources.BENSON;
+import static seedu.address.testutil.TypicalSources.CARL;
+import static seedu.address.testutil.TypicalSources.DANIEL;
+import static seedu.address.testutil.TypicalSources.ELLE;
+import static seedu.address.testutil.TypicalSources.GEORGE;
+import static seedu.address.testutil.TypicalSources.getTypicalDeletedSources;
+import static seedu.address.testutil.TypicalSources.getTypicalSourceManager;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
 
 import org.junit.Test;
 
@@ -22,7 +33,6 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.source.SourceContainsKeywordsPredicate;
 
-import java.util.*;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code SearchCommand}.

--- a/src/test/java/seedu/address/logic/parser/SearchCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SearchCommandParserTest.java
@@ -27,7 +27,6 @@ public class SearchCommandParserTest {
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, SearchCommand.MESSAGE_USAGE));
     }
 
-    @Ignore
     @Test
     public void parse_emptyPrefixArgs_returnsSearchCommand() {
         String input = " " + PREFIX_DETAILS + " ";
@@ -37,7 +36,6 @@ public class SearchCommandParserTest {
         assertParseSuccess(parser, " " + PREFIX_DETAILS + " ", expectedSearchCommand);
     }
 
-    @Ignore
     @Test
     public void parse_validArgs_returnsSearchCommand() {
         String input = TITLE_DESC_AMY;
@@ -50,7 +48,6 @@ public class SearchCommandParserTest {
         assertParseSuccess(parser, "\n \t" + TITLE_DESC_AMY, expectedSearchCommand);
     }
 
-    @Ignore
     @Test
     public void parse_validMultipleArgs_returnsSearchCommand() {
         String input = TYPE_DESC_AMY + TYPE_DESC_AMY;
@@ -60,7 +57,6 @@ public class SearchCommandParserTest {
         assertParseSuccess(parser, TYPE_DESC_AMY + TYPE_DESC_AMY, expectedSearchCommand);
     }
 
-    @Ignore
     @Test
     public void parse_validCompoundArgs_returnsSearchCommand() {
         String input = TYPE_DESC_AMY + TAG_DESC_BAR;

--- a/src/test/java/seedu/address/logic/parser/SearchCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SearchCommandParserTest.java
@@ -4,9 +4,6 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_BAR;
 import static seedu.address.logic.commands.CommandTestUtil.TITLE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.TYPE_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_BAR;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TITLE_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TYPE_AMY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DETAILS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
@@ -33,20 +30,22 @@ public class SearchCommandParserTest {
     @Ignore
     @Test
     public void parse_emptyPrefixArgs_returnsSearchCommand() {
-        ArgumentMultimap argMultimap = new ArgumentMultimap();
-        argMultimap.put(PREFIX_DETAILS, "");
+        String input = " " + PREFIX_DETAILS + " ";
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(input,
+                PREFIX_TITLE, PREFIX_TYPE, PREFIX_DETAILS, PREFIX_TAG);
         SearchCommand expectedSearchCommand = new SearchCommand(new SourceContainsKeywordsPredicate(argMultimap));
-        assertParseSuccess(parser, PREFIX_DETAILS + " ", expectedSearchCommand);
+        assertParseSuccess(parser, " " + PREFIX_DETAILS + " ", expectedSearchCommand);
     }
 
     @Ignore
     @Test
     public void parse_validArgs_returnsSearchCommand() {
-        ArgumentMultimap argMultimap = new ArgumentMultimap();
-        argMultimap.put(PREFIX_TITLE, VALID_TITLE_AMY);
+        String input = TITLE_DESC_AMY;
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(input,
+                PREFIX_TITLE, PREFIX_TYPE, PREFIX_DETAILS, PREFIX_TAG);
         // no leading and trailing whitespaces
         SearchCommand expectedSearchCommand = new SearchCommand(new SourceContainsKeywordsPredicate(argMultimap));
-        assertParseSuccess(parser, PREFIX_TITLE + VALID_TITLE_AMY, expectedSearchCommand);
+        assertParseSuccess(parser, TITLE_DESC_AMY, expectedSearchCommand);
         // multiple whitespaces between keywords
         assertParseSuccess(parser, "\n \t" + TITLE_DESC_AMY, expectedSearchCommand);
     }
@@ -54,9 +53,9 @@ public class SearchCommandParserTest {
     @Ignore
     @Test
     public void parse_validMultipleArgs_returnsSearchCommand() {
-        ArgumentMultimap argMultimap = new ArgumentMultimap();
-        argMultimap.put(PREFIX_TYPE, VALID_TYPE_AMY);
-        argMultimap.put(PREFIX_TYPE, VALID_TYPE_AMY);
+        String input = TYPE_DESC_AMY + TYPE_DESC_AMY;
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(input,
+                PREFIX_TITLE, PREFIX_TYPE, PREFIX_DETAILS, PREFIX_TAG);
         SearchCommand expectedSearchCommand = new SearchCommand(new SourceContainsKeywordsPredicate(argMultimap));
         assertParseSuccess(parser, TYPE_DESC_AMY + TYPE_DESC_AMY, expectedSearchCommand);
     }
@@ -64,9 +63,9 @@ public class SearchCommandParserTest {
     @Ignore
     @Test
     public void parse_validCompoundArgs_returnsSearchCommand() {
-        ArgumentMultimap argMultimap = new ArgumentMultimap();
-        argMultimap.put(PREFIX_TYPE, VALID_TYPE_AMY);
-        argMultimap.put(PREFIX_TAG, VALID_TAG_BAR);
+        String input = TYPE_DESC_AMY + TAG_DESC_BAR;
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(input,
+                PREFIX_TITLE, PREFIX_TYPE, PREFIX_DETAILS, PREFIX_TAG);
         SearchCommand expectedSearchCommand = new SearchCommand(new SourceContainsKeywordsPredicate(argMultimap));
         assertParseSuccess(parser, TYPE_DESC_AMY + TAG_DESC_BAR, expectedSearchCommand);
     }

--- a/src/test/java/seedu/address/logic/parser/SearchCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SearchCommandParserTest.java
@@ -1,17 +1,24 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_BAR;
+import static seedu.address.logic.commands.CommandTestUtil.TITLE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.TYPE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_BAR;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TITLE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TYPE_AMY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DETAILS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import seedu.address.logic.commands.SearchCommand;
 import seedu.address.model.source.SourceContainsKeywordsPredicate;
-
-import java.util.ArrayList;
-import java.util.Arrays;
 
 public class SearchCommandParserTest {
 
@@ -19,21 +26,49 @@ public class SearchCommandParserTest {
 
     @Test
     public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, SearchCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SearchCommand.MESSAGE_USAGE));
     }
 
+    @Ignore
     @Test
-    public void parse_validArgs_returnsFindCommand() {
+    public void parse_emptyPrefixArgs_returnsSearchCommand() {
         ArgumentMultimap argMultimap = new ArgumentMultimap();
-        argMultimap.put(PREFIX_TITLE, "alice");
-//        argMultimap.put(PREFIX_TYPE, "");
-//        argMultimap.put(PREFIX_DETAILS, "_detail");
-//        argMultimap.put(PREFIX_TAG, "end");
+        argMultimap.put(PREFIX_DETAILS, "");
+        SearchCommand expectedSearchCommand = new SearchCommand(new SourceContainsKeywordsPredicate(argMultimap));
+        assertParseSuccess(parser, PREFIX_DETAILS + " ", expectedSearchCommand);
+    }
+
+    @Ignore
+    @Test
+    public void parse_validArgs_returnsSearchCommand() {
+        ArgumentMultimap argMultimap = new ArgumentMultimap();
+        argMultimap.put(PREFIX_TITLE, VALID_TITLE_AMY);
         // no leading and trailing whitespaces
-        SearchCommand expectedFindCommand = new SearchCommand(new SourceContainsKeywordsPredicate(argMultimap));
-        assertParseSuccess(parser, "i/alice", expectedFindCommand);
+        SearchCommand expectedSearchCommand = new SearchCommand(new SourceContainsKeywordsPredicate(argMultimap));
+        assertParseSuccess(parser, PREFIX_TITLE + VALID_TITLE_AMY, expectedSearchCommand);
         // multiple whitespaces between keywords
-        //assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+        assertParseSuccess(parser, "\n \t" + TITLE_DESC_AMY, expectedSearchCommand);
+    }
+
+    @Ignore
+    @Test
+    public void parse_validMultipleArgs_returnsSearchCommand() {
+        ArgumentMultimap argMultimap = new ArgumentMultimap();
+        argMultimap.put(PREFIX_TYPE, VALID_TYPE_AMY);
+        argMultimap.put(PREFIX_TYPE, VALID_TYPE_AMY);
+        SearchCommand expectedSearchCommand = new SearchCommand(new SourceContainsKeywordsPredicate(argMultimap));
+        assertParseSuccess(parser, TYPE_DESC_AMY + TYPE_DESC_AMY, expectedSearchCommand);
+    }
+
+    @Ignore
+    @Test
+    public void parse_validCompoundArgs_returnsSearchCommand() {
+        ArgumentMultimap argMultimap = new ArgumentMultimap();
+        argMultimap.put(PREFIX_TYPE, VALID_TYPE_AMY);
+        argMultimap.put(PREFIX_TAG, VALID_TAG_BAR);
+        SearchCommand expectedSearchCommand = new SearchCommand(new SourceContainsKeywordsPredicate(argMultimap));
+        assertParseSuccess(parser, TYPE_DESC_AMY + TAG_DESC_BAR, expectedSearchCommand);
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/SearchCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SearchCommandParserTest.java
@@ -1,11 +1,18 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.*;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import org.junit.Test;
 
 import seedu.address.logic.commands.SearchCommand;
+import seedu.address.model.source.SourceContainsKeywordsPredicate;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
 public class SearchCommandParserTest {
 
     private SearchCommandParser parser = new SearchCommandParser();
@@ -17,11 +24,14 @@ public class SearchCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsFindCommand() {
+        ArgumentMultimap argMultimap = new ArgumentMultimap();
+        argMultimap.put(PREFIX_TITLE, "alice");
+//        argMultimap.put(PREFIX_TYPE, "");
+//        argMultimap.put(PREFIX_DETAILS, "_detail");
+//        argMultimap.put(PREFIX_TAG, "end");
         // no leading and trailing whitespaces
-        //SearchCommand expectedFindCommand =
-                //new SearchCommand(new SourceContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
-        //assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
-
+        SearchCommand expectedFindCommand = new SearchCommand(new SourceContainsKeywordsPredicate(argMultimap));
+        assertParseSuccess(parser, "i/alice", expectedFindCommand);
         // multiple whitespaces between keywords
         //assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
     }

--- a/src/test/java/seedu/address/logic/parser/SearchCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SearchCommandParserTest.java
@@ -11,7 +11,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import seedu.address.logic.commands.SearchCommand;

--- a/src/test/java/seedu/address/logic/parser/SourceManagerParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SourceManagerParserTest.java
@@ -4,31 +4,24 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.commands.CommandTestUtil.TITLE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TITLE_AMY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_SOURCE;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import seedu.address.logic.commands.AddCommand;
-import seedu.address.logic.commands.ClearCommand;
-import seedu.address.logic.commands.CountCommand;
-import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.ExitCommand;
-import seedu.address.logic.commands.HelpCommand;
-import seedu.address.logic.commands.HistoryCommand;
-import seedu.address.logic.commands.ListCommand;
-import seedu.address.logic.commands.RedoCommand;
-import seedu.address.logic.commands.SelectCommand;
-import seedu.address.logic.commands.UndoCommand;
+import seedu.address.logic.commands.*;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.source.Source;
+import seedu.address.model.source.SourceContainsKeywordsPredicate;
 import seedu.address.testutil.EditSourceDescriptorBuilder;
 import seedu.address.testutil.SourceBuilder;
 import seedu.address.testutil.SourceUtil;
-
 
 public class SourceManagerParserTest {
     @Rule
@@ -81,12 +74,14 @@ public class SourceManagerParserTest {
         assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3") instanceof ExitCommand);
     }
 
+    @Ignore
     @Test
-    public void parseCommand_find() throws Exception {
-        //List<String> keywords = Arrays.asList("foo", "bar", "baz");
-        //SearchCommand command = (SearchCommand) parser.parseCommand(
-                //SearchCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
-        //assertEquals(new SearchCommand(new SourceContainsKeywordsPredicate(keywords)), command);
+    public void parseCommand_search() throws Exception {
+        ArgumentMultimap argMultimap = new ArgumentMultimap();
+        argMultimap.put(PREFIX_TITLE, VALID_TITLE_AMY);
+        SearchCommand command = (SearchCommand) parser.parseCommand(
+                SearchCommand.COMMAND_WORD + TITLE_DESC_AMY );
+        assertEquals(new SearchCommand(new SourceContainsKeywordsPredicate(argMultimap)), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/SourceManagerParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SourceManagerParserTest.java
@@ -12,12 +12,23 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_SOURCE;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import seedu.address.logic.commands.*;
+import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.CountCommand;
+import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.HistoryCommand;
+import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.RedoCommand;
+import seedu.address.logic.commands.SearchCommand;
+import seedu.address.logic.commands.SelectCommand;
+import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.source.Source;
 import seedu.address.model.source.SourceContainsKeywordsPredicate;
@@ -82,7 +93,7 @@ public class SourceManagerParserTest {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(input,
                 PREFIX_TITLE, PREFIX_TYPE, PREFIX_DETAILS, PREFIX_TAG);
         SearchCommand command = (SearchCommand) parser.parseCommand(
-                SearchCommand.COMMAND_WORD + TITLE_DESC_AMY );
+                SearchCommand.COMMAND_WORD + TITLE_DESC_AMY);
         assertEquals(new SearchCommand(new SourceContainsKeywordsPredicate(argMultimap)), command);
     }
 

--- a/src/test/java/seedu/address/logic/parser/SourceManagerParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SourceManagerParserTest.java
@@ -5,8 +5,10 @@ import static org.junit.Assert.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.TITLE_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TITLE_AMY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DETAILS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_SOURCE;
 
 import org.junit.Before;
@@ -77,8 +79,9 @@ public class SourceManagerParserTest {
     @Ignore
     @Test
     public void parseCommand_search() throws Exception {
-        ArgumentMultimap argMultimap = new ArgumentMultimap();
-        argMultimap.put(PREFIX_TITLE, VALID_TITLE_AMY);
+        String input = TITLE_DESC_AMY;
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(input,
+                PREFIX_TITLE, PREFIX_TYPE, PREFIX_DETAILS, PREFIX_TAG);
         SearchCommand command = (SearchCommand) parser.parseCommand(
                 SearchCommand.COMMAND_WORD + TITLE_DESC_AMY );
         assertEquals(new SearchCommand(new SourceContainsKeywordsPredicate(argMultimap)), command);

--- a/src/test/java/seedu/address/logic/parser/SourceManagerParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SourceManagerParserTest.java
@@ -76,7 +76,6 @@ public class SourceManagerParserTest {
         assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3") instanceof ExitCommand);
     }
 
-    @Ignore
     @Test
     public void parseCommand_search() throws Exception {
         String input = TITLE_DESC_AMY;


### PR DESCRIPTION
This major PR marks a great milestone in the progress of our very own search feature:

- search command now allows multiple arguments of same tags and searches in conjunction
- all existing logic tests and parser tests fixed
-  implemented new logic and parser tests for edge cases 
- updated sophisticated hashcode() methods for search command related classes
- update equals() comparison of ArgumentMultimap class which was causing parser tests to fail
- updated UG, DG, PPP to reflect these changes

partially implements #148, #3, #207