### PR TITLE
Modified regex for tags again to remove special characters

### DIFF
--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -9,7 +9,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = 
+    public static final String MESSAGE_CONSTRAINTS =
             "Tag names should only contain alphanumeric characters and spaces.";
     public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
 

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -9,8 +9,9 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tag names should not start with a space.";
-    public static final String VALIDATION_REGEX = "[^\\s].*";
+    public static final String MESSAGE_CONSTRAINTS = 
+            "Tag names should only contain alphanumeric characters and spaces.";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
 
     public final String tagName;
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -50,8 +50,9 @@ public class CommandTestUtil {
 
     public static final String INVALID_TITLE_DESC = " " + PREFIX_TITLE + "!@#$%^&*()"; // Special characters not allowed
     public static final String INVALID_TYPE_DESC = " " + PREFIX_TYPE + "!@#$%^&*()"; // Special characters not allowed
+    public static final String INVALID_AUTHOR_DESC = " " + PREFIX_AUTHOR; // empty string not allowed for author
     public static final String INVALID_DETAIL_DESC = " " + PREFIX_DETAILS; // empty string not allowed for details
-    public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + " "; // empty tag
+    public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "footag*"; // tags cannot have special characters
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -28,7 +28,6 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 import static seedu.address.testutil.TypicalSources.ENGINEERING;
 import static seedu.address.testutil.TypicalSources.NETWORK;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import seedu.address.logic.commands.AddCommand;
@@ -147,7 +146,6 @@ public class AddCommandParserTest {
                 expectedMessage);
     }
 
-    @Ignore
     @Test
     public void parse_invalidTags_failure() {
         // invalid tag

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -26,7 +26,6 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_SOURCE;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_SOURCE;
 import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_SOURCE;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import seedu.address.commons.core.index.Index;
@@ -74,7 +73,6 @@ public class EditCommandParserTest {
         assertParseFailure(parser, "1 j/ string", MESSAGE_INVALID_FORMAT);
     }
 
-    @Ignore
     @Test
     public void parse_invalidTags_failure() {
         assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -137,7 +137,6 @@ public class ParserUtilTest {
         ParserUtil.parseTag(null);
     }
 
-    @Ignore
     @Test
     public void parseTag_invalidValue_throwsParseException() throws Exception {
         thrown.expect(ParseException.class);

--- a/src/test/java/seedu/address/storage/JsonAdaptedSourceTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedSourceTest.java
@@ -8,7 +8,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import seedu.address.commons.exceptions.IllegalValueException;
@@ -82,7 +81,6 @@ public class JsonAdaptedSourceTest {
         Assert.assertThrows(IllegalValueException.class, expectedMessage, source::toModelType);
     }
 
-    @Ignore
     @Test
     public void toModelType_invalidTags_throwsIllegalValueException() {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);


### PR DESCRIPTION
Special characters are now invalid, tags can only accept alphanumeric characters and spaces.

Reintegrated tests for invalid tags.

#185 